### PR TITLE
Add more dash punctuation to regex

### DIFF
--- a/mcs/class/Mono.Options/Mono.Options/Options.cs
+++ b/mcs/class/Mono.Options/Mono.Options/Options.cs
@@ -1069,7 +1069,7 @@ namespace Mono.Options
 		}
 
 		private readonly Regex ValueOption = new Regex (
-			@"^(?<flag>--|-|/)(?<name>[^:=]+)((?<sep>[:=])(?<value>.*))?$");
+			@"^(?<flag>--|-|–|––|—|——|/)(?<name>[^:=]+)((?<sep>[:=])(?<value>.*))?$");
 
 		protected bool GetOptionParts (string argument, out string flag, out string name, out string sep, out string value)
 		{


### PR DESCRIPTION
To avoid problem with dashes punctuation with ASCII 8211(en dash), 8212
(em dash), regex was extended.